### PR TITLE
Use files from CDN instead of Bower

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,0 @@
-{
-  "directory": "bin/lib"
-}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ You can download the extension from the chrome store and get updated automatical
 
 # Setup and run locally
 - Clone the project
-- Run `bower i` the get the components
 - Open Chrome in `chrome://extensions/`
 - Check `Developer Mode`
 - Click `Load unpacked extension`

--- a/bin/app/app.html
+++ b/bin/app/app.html
@@ -5,17 +5,18 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta charset="utf-8">
 
-    <script src="../lib/lodash/lodash.min.js"></script>
-    <script src="../lib/angular/angular.min.js"></script>
-    <script src="../lib/angular-sanitize/angular-sanitize.min.js"></script>
-    <script src="../lib/angular-ui-router/release/angular-ui-router.min.js"></script>
-    <script src="../lib/ace-builds/src-min-noconflict/ace.js"></script>
-    <script src="../lib/angular-ui-ace/ui-ace.min.js"></script>
-    <script src="../lib/angular-hotkeys/build/hotkeys.min.js"></script>
-    <script src="../lib/angular-mass-autocomplete/massautocomplete.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.6.0/lodash.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.3.20/angular.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-sanitize/1.3.15/angular-sanitize.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-router/0.2.14/angular-ui-router.min.js"></script>
 
-    <link rel="stylesheet" href="../lib/font-awesome/css/font-awesome.min.css"/>
-    <link rel="stylesheet" href="../lib/angular-mass-autocomplete/massautocomplete.theme.css"/>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.3.3/ace.js"></script>
+    <script src="https://cdn.rawgit.com/angular-ui/ui-ace/36844ff7c0e0d9445bc8e31514d7f0f59cb8b048/ui-ace.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-hotkeys/1.4.5/hotkeys.min.js"></script>
+    <script src="https://cdn.rawgit.com/hakib/MassAutocomplete/36759f9f509e4301c29c028e1866ae274d193eb5/massautocomplete.min.js"></script>
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.3.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="https://cdn.rawgit.com/hakib/MassAutocomplete/36759f9f509e4301c29c028e1866ae274d193eb5/massautocomplete.theme.css">
 
     <script src="js/config.js"></script>
     <script src="js/common/mixins.js"></script>

--- a/bin/manifest.json
+++ b/bin/manifest.json
@@ -40,5 +40,5 @@
     }
   ],
   "manifest_version": 2,
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'"
+  "content_security_policy": "script-src 'self' 'unsafe-eval' https://cdnjs.cloudflare.com https://cdn.rawgit.com; object-src 'self'"
 }


### PR DESCRIPTION
Bower is outdated.  We can stay with CDN or further migrate to NPM.