### PR TITLE
Remove Node v7 from the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - node
   - 8
-  - 7
   - 6
 
 # Upgrade to the latest version of NPM to be able to use npm ci


### PR DESCRIPTION
It is not supported by the latest version of npm.