### PR TITLE
Enable --ci for Jest in CI environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 
 script:
   - npm run lint
-  - npm test
+  - npm test -- --ci
 
 # Limit "Build pushed branches" to only the master branch
 # https://travis-ci.org/luangong/WebOverride/settings


### PR DESCRIPTION
Instead of the regular behavior of storing a new snapshot automatically, it will fail the test and require Jest to be run with `--updateSnapshot`.

http://jestjs.io/docs/en/cli#ci