### PR TITLE
Simplify code with new ECMAScript methods

### DIFF
--- a/content_script/content_script.js
+++ b/content_script/content_script.js
@@ -1,21 +1,19 @@
 'use strict';
 
 function initialize(overrides, document, location) {
-  // Filter out inactive and irrelevant overrides
-  var relevantOverrides = [];
-  for (var id in overrides) {
-    if (overrides.hasOwnProperty(id) && overrides[id].active) {
-      var query = overrides[id].urlQueries.filter(function (urlQuery) {
-        return new RegExp(urlQuery).test(location.href);
-      });
-      if (query.length > 0) {
-        relevantOverrides.push(overrides[id]);
-      }
+  Object.values(overrides).forEach(override => {
+    // Ignore inactive overrides
+    if (!override.active) {
+      return;
+    }
+
+    // Ignore overrides that don’t have matching URL patterns
+    if (!override.urlQueries.some(query => (new RegExp(query)).test(location.href))) {
+      return;
     }
   }
 
-  // Activate all relevant overrides
-  relevantOverrides.forEach(function (override) {
+    // Inject HTML, CSS, and JS for matching overrides
     if (override.htmlContent) {
       document.body.innerHTML += override.htmlContent;
     }
@@ -42,10 +40,7 @@ function initialize(overrides, document, location) {
 function onMessage(message, location) {
   if (message.request == 'overrideUpdated' && message.urlQueries) {
     // Check if any of the overrides urls pass the regexp test
-    var overrideRelevant = message.urlQueries.filter(function (urlQuery) {
-      return new RegExp(urlQuery).test(location.href);
-    });
-    if (overrideRelevant.length > 0) {
+    if (message.urlQueries.some(query => (new RegExp(query)).test(location.href))) {
       location.reload();
     }
   }


### PR DESCRIPTION
This commits uses [`Object.values()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values) from ECMAScript 2017 (ES8) and [`Array.prototype.some()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some) from ECMAScript 2015 (ES6) to simplify code.