### PR TITLE
Fix an issue of incorrectly checking browser / Node environment

### DIFF
--- a/content_script/content_script.js
+++ b/content_script/content_script.js
@@ -46,7 +46,7 @@ function onMessage(message, location) {
 }
 
 // Export functions for the Node environment
-if (module && module.exports) {
+if (typeof module !== 'undefined' && module.exports) {
   module.exports = { initialize, onMessage };
 } else {
   // Get all the scripts and activate the relevant ones


### PR DESCRIPTION
The original way of checking whether the code is running in a browser or
on Node.js causes the following error:

```
Uncaught ReferenceError: module is not defined
```